### PR TITLE
Added function to created extended GDSII file with SG13 features

### DIFF
--- a/examples_SG13G2/balun_forEM.py
+++ b/examples_SG13G2/balun_forEM.py
@@ -1,38 +1,35 @@
-# Single ended inductor example
+# Balun for EM simulation
 
-from pclab import *
-import math
+import math, sys, os
+
+# import inductor shape library
+from pclab import *   # https://github.com/dgrujic/pcLab
+
 
 tech = Technology("SG13G2.tech")
 
 w = 4.0
 s = 2.0
+d_outer = 200 
 nturns = 3.0
+
 sig_lay = "TopMetal1"
 underpass_lay = "Metal5"
 secondary_lay= "TopMetal2"
 ind_geom = "octagon" # valid choices: "rect", "octagon"
 
 
-d_outer = 0 # start from a diameter that is too small
-
 # Generate balun 
 balun = balun2x1_broadsidecoupled(tech)
-# valid = balun.setupGeometry(d_outer, w, s, sig_lay, underpass_lay, ind_geom)
 valid = balun.setupGeometry(d_outer, w, w, 0.0, sig_lay, underpass_lay, secondary_lay, s, ind_geom)
-                            
-if not valid:
-    print(f"Specified d_outer {d_outer} is too small, change to minimum possible diameter")
-    d_outer = balun.get_min_diameter()
-    print(f"=> changed to d_outer min={d_outer}")
-    #balun.setupGeometry(d_outer, w, s, sig_lay, underpass_lay, ind_geom)
-    valid = balun.setupGeometry(d_outer, w, w, 0.0, sig_lay, underpass_lay, secondary_lay, s, ind_geom)
-
-balun_name = f"{type(balun).__name__}_{ind_geom}_do{d_outer}_w{w}_s{s}"
 balun.genGeometry()
+
+# Create layout file
+balun_name = f"{type(balun).__name__}_{ind_geom}_do{d_outer}_w{w}_s{s}"
+filename = balun_name + '.gds'
 balun.genGDSII(balun_name + '.gds', structName = balun_name)
 print('Created file ',balun_name + '.gds')
 
-
-
+# create GDSII with ports for EM simulation, file suffix is "_forEM.gds" 
+gds_pin2viaport(filename, width=w, port_layer_start=201, add_frame=True, frame_layer=8, frame_margin=20)             
 

--- a/pclab/__init__.py
+++ b/pclab/__init__.py
@@ -18,3 +18,4 @@ from .pclInductor import *
 from .pclTech import *
 from .pin2port import *
 from .indcalc import *
+from .ihp_sg13_features import *

--- a/pclab/ihp_sg13_features.py
+++ b/pclab/ihp_sg13_features.py
@@ -1,0 +1,141 @@
+# Copyright 2026 Volker Muehlhaus (volker@muehlhaus.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This code adds IHP SG13G2-specific layout features to an existing GDSII file
+
+import os, gdspy, math
+
+
+# ------------------------------------------------------------------------------
+# Settings that are specific to IHP SG13G2 OPDK layer numbers and GDSII data types
+
+EXTRA_LAYER_PURPOSE_PAIRS = [
+    (1,23), # Activ.nofill
+    (5,23), # Gatpoly nofill
+    (8,23), # Metal1.nofill
+    (10,23), # Metal2.nofill
+    (30,23), # Metal3.nofill
+    (50,23), # Metal4.nofill
+    (67,23), # Metal5.nofill
+    (126,23), # TopMetal1.nofill
+    (134,23), # TopMetal2.nofill
+    (46,21), # Pwell.block
+    (148,0), # NoRCX.drawing
+    (27,0)  # IND.drawing
+]
+PIN_PURPOSE = 2  # data type for pin shapes on metal layers
+
+IND_PIN = (27,2)    # layer and purpose used for inductor pins in SG13G2 OPDK
+IND_TEXT = (27,25)  # layer and purpose used for inductor pin labels in SG13G2 OPDK
+
+TEXT_DRAWING = (63,0)  # layer to show additional text information
+
+GRID = 0.01
+
+# ------------------------------------------------------------------------------
+
+
+
+def gds_add_sg13_features (input_filename, output_filename, optional_text='', pin_size=2):
+    if os.path.isfile(input_filename):
+        output_library = gdspy.GdsLibrary(infile=input_filename)
+
+        toplevel_cell_list = output_library.top_level()
+        cell = output_library.cells.get('', toplevel_cell_list[0])
+
+        # get bounding box, so that we can design the extra layer polygons
+        bbox = cell.get_bounding_box()
+
+        xmin = bbox[0][0]
+        ymin = bbox[0][1]
+        xmax = bbox[1][0]
+        ymax = bbox[1][1]
+
+        # assume that we have an inductor with center at (0,0)
+        # get outer coordinates (should be at feedline pins, but we evaluate all drawing now)
+        # Note this is a coordinate, NOT the diameter
+        max_value = max(abs(xmin), abs(xmax), abs(ymin), abs(ymax))
+        
+        c = max_value * (1 - 1/(2*math.sqrt(2)))
+        c = round(c / GRID) * GRID 
+
+        points = [
+            (-max_value + c, -max_value),
+            ( max_value - c, -max_value),
+            ( max_value, -max_value + c),
+            ( max_value,  max_value - c),
+            ( max_value - c,  max_value),
+            (-max_value + c,  max_value),
+            (-max_value,  max_value - c),
+            (-max_value, -max_value + c),
+        ]
+
+        # Now iterate over the EXTRA_LAYER_PURPOSE_PAIRS and add an octagon on each of them
+        for LPP in EXTRA_LAYER_PURPOSE_PAIRS:
+            layer, datatype = LPP
+            octagon = gdspy.Polygon(points, layer=layer, datatype=datatype)
+            cell.add(octagon)
+
+
+        # The second step is to add pin shapes on the metal layers AND the IND layer,
+        # and also add the pin text on IND.text 
+
+        done_list = []
+
+        for label in cell.labels:
+            xlabel = label.position[0]
+            ylabel = label.position[1]
+            pintext = label.text
+            metallayer = label.layer
+
+            if pintext not in done_list:
+
+                # create pin shape on the metal layer where that pin is
+                p1 = (xlabel-pin_size/2, ylabel-pin_size/2)
+                p2 = (xlabel+pin_size/2, ylabel+pin_size/2)
+                rect = gdspy.Rectangle(p1, p2, layer=metallayer, datatype=PIN_PURPOSE)            
+                cell.add(rect)
+
+                # also add pin shape on PIN layer
+                rect = gdspy.Rectangle(p1, p2, layer=IND_PIN[0], datatype=IND_PIN[1])            
+                cell.add(rect)
+
+                # clone pin label text to layer IND.text
+                label = gdspy.Label(pintext, (xlabel, ylabel), layer=IND_TEXT[0], texttype=IND_TEXT[1])
+                cell.add(label)
+
+                # mark this pin label done, so that we don't repeat with extra pins created just now
+                done_list.append(pintext)
+
+        # remove pin labels from all metal layers (just leave them on IND_PIN)
+        cell.remove_labels(lambda label: label.layer != IND_TEXT[0])
+
+        # add optional text, used to show inductor parameters
+
+        label = gdspy.Label(optional_text, (0,0), layer=TEXT_DRAWING[0], texttype=TEXT_DRAWING[1])
+        cell.add(label)
+
+       
+        output_library.write_gds(output_filename)  
+        return True       
+    else:
+        print(f"File not found: {filename}")
+        return False
+
+
+
+if __name__ == "__main__":
+    # test code goes here
+    filename = '../indSym_octagon_N2_do68.35_w2.01_s2.01.gds'
+    gds_add_sg13_features (filename, '../final.gds', optional_text = 'line 1\nline 2\nline 3', pin_size=2)

--- a/pclab/indcalc.py
+++ b/pclab/indcalc.py
@@ -1,3 +1,18 @@
+# Copyright 2026 Volker Muehlhaus (volker@muehlhaus.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 # Inductor calculation based on Inductor Toolkit for ADS by Volker Muehlhaus
 
 import math

--- a/pclab/pin2port.py
+++ b/pclab/pin2port.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Volker Muehlhaus (volker@muehlhaus.com)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os, math, gdspy
 
 PORT_SIDE_LEFT   = 0


### PR DESCRIPTION
This creates a "final" GDSII with special layout "decoration" for IHP SG13G2 OPDK, e.g. nofill polygons and PWell.block. It also adds pin shapes on metal layers and some description on layer TEXT.drawing 

<img width="1278" height="913" alt="grafik" src="https://github.com/user-attachments/assets/635c184c-c5b2-4a7b-a22e-0dec3f81fa27" />
